### PR TITLE
Ensure users have an email attribute.

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -70,3 +70,7 @@ class RapidProUser(AbstractBaseUser, PermissionsMixin):
 
     def get_short_name(self):
         return self.username
+
+    @property
+    def email(self):
+        return self.username

--- a/accounts/tests/test_models.py
+++ b/accounts/tests/test_models.py
@@ -22,3 +22,6 @@ class UserTestCase(TestCase):
     def test_no_username(self):
         with self.assertRaises(ValueError):
             factories.UserFactory(username='')
+
+    def test_access_email(self):
+        self.assertEqual(self.user.username, self.user.email)


### PR DESCRIPTION
Wagtail assumes it during "submit for moderation" for example.
