### PR TITLE
Simply CMS page to just a rich text field.

### DIFF
--- a/portal_pages/migrations/0026_auto_20150514_1133.py
+++ b/portal_pages/migrations/0026_auto_20150514_1133.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal_pages', '0025_auto_20150514_0821'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='cmspage',
+            name='body',
+            field=wagtail.wagtailcore.fields.RichTextField(default='', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/portal_pages/models.py
+++ b/portal_pages/models.py
@@ -146,15 +146,11 @@ HighlightItem.panels = [
 
 
 class CMSPage(Page):
-    body = StreamField([
-        ('heading', blocks.CharBlock(classname="full title")),
-        ('paragraph', blocks.RichTextBlock()),
-        ('image', ImageChooserBlock()),
-    ])
+    body = RichTextField(blank=True, default='')
 
 CMSPage.content_panels = [
     FieldPanel('title'),
-    StreamFieldPanel('body'),
+    FieldPanel('body'),
 ]
 
 

--- a/portal_pages/templates/portal_pages/case_study_index_page.html
+++ b/portal_pages/templates/portal_pages/case_study_index_page.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
 
-{% block content %}
-
+{% block full-content %}
     <section class="highlights">
         <div class="page-width float-layout">
 
@@ -45,7 +44,7 @@
     </section>
 
     <div class="clear"></div>
-    
+
     {# Pagination - uses django.core.paginator #}
     {# Append any other url query string variables to the next and previous links - allows tag to be passed through #}
     <div class="row">
@@ -63,5 +62,4 @@
             {% endif %}
         </div>
     </div>
-
 {% endblock %}

--- a/portal_pages/templates/portal_pages/case_study_page.html
+++ b/portal_pages/templates/portal_pages/case_study_page.html
@@ -20,80 +20,74 @@
 {% endblock %}
 
 {% block content %}
-    <section class="content">
-        <div class="page-width float-layout">
-            <div class="two-thirds"><div class="cushion">
+    <div class="two-thirds"><div class="cushion">
 
-                <h1>{{ self.title }}</h1>
+        <h1>{{ self.title }}</h1>
 
-                {% if self.casestudy_index %}
+        {% if self.casestudy_index %}
 
-                    <div class="tags">
-                        {% for country in self.countries.all %}
-                            <a href="{% pageurl self.casestudy_index %}?country={{ country.country.name }}">
-                            {{ country.country.name }}
-                            </a>
-                        {% endfor %}
-                    </div>
-
-                {% endif %}
-
-                {% if self.date %}<p><small>Launched: {{ self.date }}</small></p>{% endif %}
-
-                {% if self.summary %}
-                    <p>{{ self.summary|richtext }}</p>
-                {% endif %}
-
-            </div></div>
-
-        <div class="third">
-
-            {% if self.downloadable_package %}
-                <div class="cushion">
-                    <h2>Import the Flow</h2>
-                    <a class="button" href="{{ self.downloadable_package.url }}">{{ self.downloadable_package.title }}</a>
-                </div>
-            {% endif %}
-
-            {% if self.casestudy_index %}
-
-            <div class="cushion">
-                <h2>Focus Areas</h2>
-                <div class="tags">
-                    {% for focus_area in self.focus_areas.all %}
-                    <a href="{% pageurl self.casestudy_index %}?focus_area={{ focus_area.focusarea.name }}">
-                        {{ focus_area.focusarea.name }}
+            <div class="tags">
+                {% for country in self.countries.all %}
+                    <a href="{% pageurl self.casestudy_index %}?country={{ country.country.name }}">
+                    {{ country.country.name }}
                     </a>
-                    {% endfor %}
-                </div>
+                {% endfor %}
             </div>
 
-            <div class="cushion">
-                <h2>Organizations</h2>
-                <ul>
-                    {% for organization in self.organizations.all %}
-                        <li><a href="{% pageurl self.casestudy_index %}?organization={{ organization.organization.name }}">
-                        {{ organization.organization.name }}
-                        </a></li>
-                    {% endfor %}
-                </ul>
-            </div>
+        {% endif %}
 
-            {% if self.marketplace_entry %}
-                <div class="cushion">
-                    <h2>Tech Firm</h2>
-                    <ul>
-                        <li><a href="{% pageurl self.casestudy_index %}?marketplace={{ self.marketplace_entry.title }}">
-                        {{ self.marketplace_entry.title }}
-                        </a></li>
-                    </ul>
-                </div>
-            {% endif %}
+        {% if self.date %}<p><small>Launched: {{ self.date }}</small></p>{% endif %}
 
-            {% endif %}
+        {% if self.summary %}
+            <p>{{ self.summary|richtext }}</p>
+        {% endif %}
 
+    </div></div>
+
+<div class="third">
+
+    {% if self.downloadable_package %}
+        <div class="cushion">
+            <h2>Import the Flow</h2>
+            <a class="button" href="{{ self.downloadable_package.url }}">{{ self.downloadable_package.title }}</a>
         </div>
+    {% endif %}
 
+    {% if self.casestudy_index %}
+
+    <div class="cushion">
+        <h2>Focus Areas</h2>
+        <div class="tags">
+            {% for focus_area in self.focus_areas.all %}
+            <a href="{% pageurl self.casestudy_index %}?focus_area={{ focus_area.focusarea.name }}">
+                {{ focus_area.focusarea.name }}
+            </a>
+            {% endfor %}
         </div>
-    </section>
+    </div>
+
+    <div class="cushion">
+        <h2>Organizations</h2>
+        <ul>
+            {% for organization in self.organizations.all %}
+                <li><a href="{% pageurl self.casestudy_index %}?organization={{ organization.organization.name }}">
+                {{ organization.organization.name }}
+                </a></li>
+            {% endfor %}
+        </ul>
+    </div>
+
+    {% if self.marketplace_entry %}
+        <div class="cushion">
+            <h2>Tech Firm</h2>
+            <ul>
+                <li><a href="{% pageurl self.casestudy_index %}?marketplace={{ self.marketplace_entry.title }}">
+                {{ self.marketplace_entry.title }}
+                </a></li>
+            </ul>
+        </div>
+    {% endif %}
+
+    {% endif %}
+    </div>
 {% endblock %}

--- a/portal_pages/templates/portal_pages/cms_page.html
+++ b/portal_pages/templates/portal_pages/cms_page.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
+{% load wagtailcore_tags %}
 
 {% block content %}
-    {{ self.body }}
+    {{ self.body|richtext }}
 {% endblock %}

--- a/portal_pages/templates/portal_pages/home_page.html
+++ b/portal_pages/templates/portal_pages/home_page.html
@@ -13,7 +13,7 @@
     <br><br><br>
 {% endblock %}
 
-{% block content %}
+{% block full-content %}
 <section class="highlights">
     <div class="page-width float-layout">
     {% for hlight in self.highlights.all %}

--- a/portal_pages/templates/portal_pages/marketplace_entry_page.html
+++ b/portal_pages/templates/portal_pages/marketplace_entry_page.html
@@ -20,62 +20,57 @@
 {% endblock %}
 
 {% block content %}
-    <section class="content">
-        <div class="page-width float-layout">
-            <div class="two-thirds"><div class="cushion">
+    <div class="two-thirds"><div class="cushion">
 
-                <h1>{{ self.title }}</h1>
+        <h1>{{ self.title }}</h1>
 
-                {% if self.marketplace_index %}
-                
-                    <div class="tags">
-                        {% for country in self.countries.all %}
-                            <a href="{% pageurl self.marketplace_index %}?country={{ country.country.name }}">
-                            {{ country.country.name }}
-                            </a>
-                        {% endfor %}
-                    </div>
+        {% if self.marketplace_index %}
 
-                {% endif %}
-
-                <p>{% if self.date_start %}<small>{{ self.date_start }}</small> - Present{% endif %}</p>
-                
-                {% if self.biography %}
-                    <p>{{ self.biography|richtext }}</p>
-                {% endif %}
-     
-            </div></div>
-      
-        <div class="third">
-
-            {% if self.marketplace_index %}
-
-            <div class="cushion">
-                <h2>Services</h2>
-                <div class="tags">
-                    {% for service in self.services.all %}
-                    <a href="{% pageurl self.marketplace_index %}?service={{ service.service.name }}">
-                        {{ service.service.name }}
+            <div class="tags">
+                {% for country in self.countries.all %}
+                    <a href="{% pageurl self.marketplace_index %}?country={{ country.country.name }}">
+                    {{ country.country.name }}
                     </a>
-                    {% endfor %}
-                </div>
+                {% endfor %}
             </div>
 
-            <div class="cushion">
-                <h2>Expertise</h2>
-                <ul>
-                    {% for expertise in self.expertise_tags.all %}
-                        <li><a href="{% pageurl self.marketplace_index %}?expertise={{ expertise.expertise.name }}">
-                        {{ expertise.expertise.name }}
-                        </a></li>
-                    {% endfor %}
-                </ul>
+        {% endif %}
+
+        <p>{% if self.date_start %}<small>{{ self.date_start }}</small> - Present{% endif %}</p>
+
+        {% if self.biography %}
+            <p>{{ self.biography|richtext }}</p>
+        {% endif %}
+
+    </div></div>
+
+    <div class="third">
+
+        {% if self.marketplace_index %}
+
+        <div class="cushion">
+            <h2>Services</h2>
+            <div class="tags">
+                {% for service in self.services.all %}
+                <a href="{% pageurl self.marketplace_index %}?service={{ service.service.name }}">
+                    {{ service.service.name }}
+                </a>
+                {% endfor %}
             </div>
-
-            {% endif %}
-
         </div>
 
+        <div class="cushion">
+            <h2>Expertise</h2>
+            <ul>
+                {% for expertise in self.expertise_tags.all %}
+                    <li><a href="{% pageurl self.marketplace_index %}?expertise={{ expertise.expertise.name }}">
+                    {{ expertise.expertise.name }}
+                    </a></li>
+                {% endfor %}
+            </ul>
         </div>
-    </section>
+
+        {% endif %}
+
+    </div>
 {% endblock %}

--- a/portal_pages/templates/portal_pages/marketplace_index_page.html
+++ b/portal_pages/templates/portal_pages/marketplace_index_page.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
 
-{% block content %}
-
+{% block full-content %}
     <section class="highlights">
         <div class="page-width float-layout">
 
@@ -42,7 +41,6 @@
     </section>
 
     <div class="clear"></div>
-    
     {# Pagination - uses django.core.paginator #}
     {# Append any other url query string variables to the next and previous links - allows tag to be passed through #}
     <div class="row">

--- a/rapidpro_community_portal/templates/base.html
+++ b/rapidpro_community_portal/templates/base.html
@@ -71,7 +71,13 @@
 
         {% block heading %}{% endblock %}
 
-        {% block content %}{% endblock %}
+        {% block full-content %}
+        <section class="content">
+            <div class="page-width float-layout">
+                {% block content %}{% endblock %}
+            </div>
+        </section>
+        {% endblock %}
 
         {# External javascript #}
         {% block extra_js %}{% endblock %}


### PR DESCRIPTION
Also move "basic" html/css for page content block into base template
so that there is less need to duplicate this basic page setup html
in all rendered page templates. If the basic setup for a page is not
appropriate for a page then that page can override full-content block
rather than content.
