### PR TITLE
Refs #1: Update to wagtail 1.0b2, Django 1.8

### DIFF
--- a/accounts/migrations/0002_auto_20150521_0941.py
+++ b/accounts/migrations/0002_auto_20150521_0941.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='rapidprouser',
+            name='groups',
+            field=models.ManyToManyField(related_name='user_set', to='auth.Group', related_query_name='user', help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', blank=True, verbose_name='groups'),
+        ),
+        migrations.AlterField(
+            model_name='rapidprouser',
+            name='last_login',
+            field=models.DateTimeField(verbose_name='last login', blank=True, null=True),
+        ),
+    ]

--- a/portal_pages/migrations/0031_auto_20150521_0940.py
+++ b/portal_pages/migrations/0031_auto_20150521_0940.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal_pages', '0030_marketplaceentrypage_state'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='marketplaceentrypage',
+            name='email',
+            field=models.EmailField(blank=True, max_length=254),
+        ),
+    ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,19 +1,18 @@
 psycopg2==2.6
 
 # Wagtail and what it pulls in
-wagtail==1.0b1
-Django==1.7.7
+BeautifulSoup4==4.3.2
+Django==1.8.2
 django-appconf==1.0.1
-django_compressor==1.4
-django-treebeard==3.0
+django_compressor==1.5
 django-modelcluster==0.6.2
-django-taggit==0.12.3
-django-libsass==0.2
+django-sendfile==0.3.7
+django-taggit==0.14.0
+django-treebeard==3.0
 html5lib==0.999
-libsass==0.7.0
 Pillow==2.8.1
-requests==2.6.0
+requests==2.7.0
 six==1.9.0
 Unidecode==0.4.17
-BeautifulSoup4==4.3.2
-Willow==0.1
+wagtail==1.0b2
+Willow==0.2


### PR DESCRIPTION
...and update to levels 1.0b2-pulled levels of all the deps
wagtail pulls in. Changes in Django 1.8 result in a couple of
migrations for our accounts and portal_pages app.
