### PR TITLE
Remove non-functional uservoice.js

### DIFF
--- a/rapidpro_community_portal/static/js/uservoice.js
+++ b/rapidpro_community_portal/static/js/uservoice.js
@@ -1,4 +1,0 @@
-if (window.location.hostname !== "localhost") {
-	conditionalLoad(null, '//widget.uservoice.com/lYDl4etqM2WtGg6BKkxWg.js');
-	UserVoice = window.UserVoice || [];
-}

--- a/rapidpro_community_portal/templates/base.html
+++ b/rapidpro_community_portal/templates/base.html
@@ -27,7 +27,6 @@
         <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic" type="text/css" rel="stylesheet">
 
         <script type="text/javascript" src="{% static 'js/flickity.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/uservoice.js' %}"></script>
 
         {% block extra_css %}{% endblock %}
     </head>


### PR DESCRIPTION
I'm not sure why we have this since so far as I know the link
to uservoice on this site will simply be links, nothing programmatic.
As-is it is causing a javascript error as it's assuming something has
provided a conditionalLoad function and we don't have whatever that is
in place. Until we hear some javascript for uservoice is needed it's
best to simply remove it.
