### PR TITLE
Refs #94: Remove google linkhelp js on 404 page.

### DIFF
--- a/rapidpro_community_portal/templates/404.html
+++ b/rapidpro_community_portal/templates/404.html
@@ -13,10 +13,3 @@
         <li>an out-of-date link</li>
     </ul>
 {% endblock %}
-
-{% block extra-js %}
-    <script>
-    var GOOG_FIXURL_LANG = (navigator.language || '').slice(0,2),GOOG_FIXURL_SITE = location.host;
-    </script>
-    <script src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
-{% endblock %}


### PR DESCRIPTION
This is a start, may want to improve content also. But first get rid of not-very-helpful and badly positioned linkhelp stuff.
