### PR TITLE
Remove odd "out-denting" of no results message.

### DIFF
--- a/portal_pages/templates/portal_pages/case_study_index_page.html
+++ b/portal_pages/templates/portal_pages/case_study_index_page.html
@@ -60,13 +60,11 @@
                     {% endif %}
 
                     <div class="flex-layout">
-                    {# Uses serve method defined in models.py - allows for paging if required #}
-                    {# See also standard index for creating a listing with a tag #}
-                    {% for page in casestudies %}
-                        {% include "portal_pages/includes/page_list_item.html" %}
-                    {% empty %}
-                        <strong>No case studies found</strong>
-                    {% endfor %}
+                        {% for page in casestudies %}
+                            {% include "portal_pages/includes/page_list_item.html" %}
+                        {% empty %}
+                            {% include "portal_pages/includes/empty_search_filter.html" with things="case studies" %}
+                        {% endfor %}
                     </div>
 
                     {# Pagination - uses django.core.paginator #}

--- a/portal_pages/templates/portal_pages/includes/empty_search_filter.html
+++ b/portal_pages/templates/portal_pages/includes/empty_search_filter.html
@@ -1,0 +1,4 @@
+<p class="cushion">
+    <strong>No {{ things }} found for current search and filter options.</strong>
+</p>
+

--- a/portal_pages/templates/portal_pages/marketplace_index_page.html
+++ b/portal_pages/templates/portal_pages/marketplace_index_page.html
@@ -54,14 +54,11 @@
                     {% endif %}
 
                     <div class="flex-layout">
-                    {# Uses serve method defined in models.py - allows for paging if required #}
-                    {# See also standard index for creating a listing with a tag #}
-
-                    {% for page in marketplace_entries %}
-                        {% include "portal_pages/includes/page_list_item.html" %}
-                    {% empty %}
-                        No marketplace entries found
-                    {% endfor %}
+                        {% for page in marketplace_entries %}
+                            {% include "portal_pages/includes/page_list_item.html" %}
+                        {% empty %}
+                            {% include "portal_pages/includes/empty_search_filter.html" with things="marketplace entries" %}
+                        {% endfor %}
                     </div>
 
                     {# Pagination - uses django.core.paginator #}


### PR DESCRIPTION
Also make formatting/message consistent on case study and
marketplace pages.
