### PR TITLE
refs #104 sort order on snippet data (ie focus areas on case study pages)

### DIFF
--- a/portal_pages/templates/portal_pages/case_study_page.html
+++ b/portal_pages/templates/portal_pages/case_study_page.html
@@ -10,7 +10,7 @@
         {% if self.casestudy_index %}
 
             <div class="tags">
-                {% for region in self.regions.all|make_unique:"region__name" %}
+                {% for region in self.regions.all %}
                     <a href="{% pageurl self.casestudy_index %}?region={{ region.region.name }}">
                     {{ region.region.name }}
                     </a>
@@ -18,7 +18,7 @@
             </div>
 
             <div class="tags">
-                {% for country in self.countries.all|make_unique:"country__name" %}
+                {% for country in self.countries.all %}
                     <a href="{% pageurl self.casestudy_index %}?country={{ country.country.name }}">
                     {{ country.country.name }}
                     </a>
@@ -49,7 +49,7 @@
     <div class="cushion">
         <h2>Focus Areas</h2>
         <div class="tags">
-            {% for focus_area in self.focus_areas.all|make_unique:"focusarea__name" %}
+            {% for focus_area in self.focus_areas.all %}
             <a href="{% pageurl self.casestudy_index %}?focus_area={{ focus_area.focusarea.name }}">
                 {{ focus_area.focusarea.name }}
             </a>

--- a/portal_pages/templates/portal_pages/marketplace_entry_page.html
+++ b/portal_pages/templates/portal_pages/marketplace_entry_page.html
@@ -10,7 +10,7 @@
         {% if self.marketplace_index %}
 
             <div class="tags">
-                {% for region in self.regions.all|make_unique:"region__name" %}
+                {% for region in self.regions.all %}
                     <a href="{% pageurl self.marketplace_index %}?region={{ region.region.name }}">
                     {{ region.region.name }}
                     </a>
@@ -18,7 +18,7 @@
             </div>
 
             <div class="tags">
-                {% for country in self.countries.all|make_unique:"country__name" %}
+                {% for country in self.countries.all %}
                     <a href="{% pageurl self.marketplace_index %}?country={{ country.country.name }}">
                     {{ country.country.name }}
                     </a>
@@ -42,7 +42,7 @@
         <div class="cushion">
             <h2>Services</h2>
             <div class="tags">
-                {% for service in self.services.all|make_unique:"service__name" %}
+                {% for service in self.services.all %}
                 <a href="{% pageurl self.marketplace_index %}?service={{ service.service.name }}">
                     {{ service.service.name }}
                 </a>
@@ -53,7 +53,7 @@
         <div class="cushion">
             <h2>Expertise</h2>
             <div class="tags">
-                {% for expertise in self.expertise_tags.all|make_unique:"expertise__name" %}
+                {% for expertise in self.expertise_tags.all %}
                     <a href="{% pageurl self.marketplace_index %}?expertise={{ expertise.expertise.name }}">
                     {{ expertise.expertise.name }}
                     </a>


### PR DESCRIPTION
had to remove make_unique filter, was the only way to get sorting order work correctly for all snippet data, this should be ok.
