### PR TITLE
invert Case Study title/text and image on homepage

### DIFF
--- a/portal_pages/templates/portal_pages/home_page.html
+++ b/portal_pages/templates/portal_pages/home_page.html
@@ -43,9 +43,9 @@
         <div class="flex-layout">
             <section class="featured-case-study half">
                 {% image self.featured_case_study.top_image height-144 as img %}
-                <a href="{% pageurl self.featured_case_study %}"><img class="full" src="{{ img.url }}" /></a>
                 <a href="{% pageurl self.featured_case_study %}"><h2>{{ self.featured_case_study.title }}</h2></a>
                 {{ self.featured_case_study_blurb|richtext }}
+                <a href="{% pageurl self.featured_case_study %}"><img class="full" src="{{ img.url }}" /></a>
             </section>
 
             <section class="call-to-action half">


### PR DESCRIPTION
Fixes #140 
- Swap text/blurb and image of case study at bottom of home page.
