### PR TITLE
Move home page video text above video and make all video related text white

### DIFF
--- a/portal_pages/templates/portal_pages/home_page.html
+++ b/portal_pages/templates/portal_pages/home_page.html
@@ -30,8 +30,8 @@
     <section class="homepage-video">
         <div class="page-width cushion" id="homepage-video">
             <h2>{{ self.youtube_video_title }}</h2>
-            <div id="homepage-video-player"></div>
             {{ self.youtube_blurb|richtext }}
+            <div id="homepage-video-player"></div>
         </div>
     </section>
     {% endif %}

--- a/rapidpro_community_portal/static/css/main.css
+++ b/rapidpro_community_portal/static/css/main.css
@@ -177,9 +177,6 @@ ol{
 
 .homepage-video{
   background-color:#00517A;
-}
-
-.homepage-video h2{
   color: #FFF;
 }
 


### PR DESCRIPTION
Fixes #153
