### PR TITLE
fixes #191 include only blog tags on the tag list (was including image tags)

### DIFF
--- a/portal_pages/models.py
+++ b/portal_pages/models.py
@@ -743,9 +743,7 @@ class BlogIndexPage(RoutablePageMixin, Page, TopImage):
     @property
     def tags(self):
         tags = Tag.objects.filter(
-            id__in=BlogPageTag.objects.filter(
-                content_object_id__in=(BlogPage.objects.live())).values('tag')
-        )
+                portal_pages_blogpagetag_items__isnull=False).order_by('name').distinct('name')
 
         return tags
 

--- a/portal_pages/views.py
+++ b/portal_pages/views.py
@@ -144,7 +144,8 @@ def submit_blog(request, blog_index):
             send_notification(blog.get_latest_revision().id, 'submitted', None)
         return HttpResponseRedirect(blog_index.url + blog_index.reverse_subpage('thanks'))
 
-    tags = Tag.objects.filter(id__in=BlogPageTag.objects.all().values('tag')).order_by('name')
+    tags = Tag.objects.filter(
+                portal_pages_blogpagetag_items__isnull=False).order_by('name').distinct('name')
     context = {
         'form': form,
         'tags': tags,

--- a/portal_pages/views.py
+++ b/portal_pages/views.py
@@ -144,7 +144,7 @@ def submit_blog(request, blog_index):
             send_notification(blog.get_latest_revision().id, 'submitted', None)
         return HttpResponseRedirect(blog_index.url + blog_index.reverse_subpage('thanks'))
 
-    tags = Tag.objects.order_by('name')
+    tags = Tag.objects.filter(id__in=BlogPageTag.objects.all().values('tag')).order_by('name')
     context = {
         'form': form,
         'tags': tags,


### PR DESCRIPTION
Include only blog tags on the tag list (was including image tags too, which are also Tag model), on the Blog Submit page
