### PR TITLE
Fix password reset 500 error.

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,5 +1,8 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import PasswordResetForm as BasePasswordResetForm
+
 
 from wagtail.wagtailusers import forms as wagtailuser_forms
 
@@ -28,3 +31,15 @@ class UserEditForm(wagtailuser_forms.UserEditForm):
     def __init__(self, *args, **kargs):
         super().__init__(*args, **kargs)
         del self.fields['email']
+
+
+class PasswordResetForm(BasePasswordResetForm):
+
+    def get_users(self, email):
+        """Given an email, return matching user(s) who should receive a reset.
+
+        Override of Django default method since our email field IS the username.
+        """
+        active_users = get_user_model()._default_manager.filter(
+            username__iexact=email, is_active=True)
+        return (u for u in active_users if u.has_usable_password())

--- a/accounts/tests/test_password_reset.py
+++ b/accounts/tests/test_password_reset.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+from django.contrib.auth import get_user_model
+
+from . import factories
+
+
+class PasswordResetTestCase(TestCase):
+
+    def setUp(self):
+        self.user = factories.UserFactory()
+        self.url = reverse('wagtailadmin_password_reset')
+        super().setUp()
+
+    def test_get_password_reset_page(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_password_reset_page(self):
+        response = self.client.post(self.url, {
+            'email': self.user.username,
+        })
+        expected_redirect_url = reverse('wagtailadmin_password_reset_done')
+        self.assertRedirects(response, expected_redirect_url)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
 from . import views
+from . import forms
 
 urlpatterns = [
     url(r'^new/$', views.create, name='wagtailusers_users_create'),

--- a/rapidpro_community_portal/urls.py
+++ b/rapidpro_community_portal/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.auth import views as django_auth_views
 
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
@@ -9,12 +10,23 @@ from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailsearch.urls import frontend as wagtailsearch_frontend_urls
 
 from accounts import urls as accounts_urls
+from accounts import forms as accounts_forms
 
 urlpatterns = [
     url(r'^django-admin/', include(admin.site.urls)),
     # Overwrite wagtail hooks url registration for user URLs
     # https://github.com/torchbox/wagtail/issues/158
     url(r'^admin/users/', include(accounts_urls)),
+    # Overwrite wagtail admin password reset view as well
+    url(
+        r'^admin/password_reset/$', django_auth_views.password_reset, {
+            'template_name': 'wagtailadmin/account/password_reset/form.html',
+            'email_template_name': 'wagtailadmin/account/password_reset/email.txt',
+            'subject_template_name': 'wagtailadmin/account/password_reset/email_subject.txt',
+            'password_reset_form': accounts_forms.PasswordResetForm,
+            'post_reset_redirect': 'wagtailadmin_password_reset_done',
+        }, name='wagtailadmin_password_reset'
+    ),
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^search/', include(wagtailsearch_frontend_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),


### PR DESCRIPTION
Override wagtail's default password rest form with our own, which
is based off of Django's base one (wagtail has some checks for LDAP
users which we don't need) with a simple override of the get_users
method that knows email field is the username field.
