### PR TITLE
Add support for Iframes in CMSPage

### DIFF
--- a/portal_pages/models.py
+++ b/portal_pages/models.py
@@ -256,10 +256,12 @@ HighlightItem.panels = [
 
 class CMSPage(Page, TopImage):
     body = RichTextField(blank=True, default='')
+    iframe = models.CharField(max_length=255, blank=True, null=True) #Extremely unsafe: Fix it ASAP
 
 CMSPage.content_panels = [
     FieldPanel('title'),
     FieldPanel('body'),
+    FieldPanel('iframe'),
     MultiFieldPanel(TopImage.panels, "hero image"),
 ]
 

--- a/portal_pages/templates/portal_pages/cms_page.html
+++ b/portal_pages/templates/portal_pages/cms_page.html
@@ -4,6 +4,11 @@
 {% block content %}
     <div class="spacer"></div>
     <div class="cushion">
-    {{ self.body|richtext }}
+        {{ self.body|richtext }}
     </div>
+    {% if self.iframe %}
+        <div class="cushion">
+            {{ self.iframe|richtext }}
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Add support for Iframe on CMS page. 

May not be the safest option but luckily only admins can access that part of the site. Requirement need is urgent